### PR TITLE
fix: missing props

### DIFF
--- a/6-fetching-data/components/MyLayout.js
+++ b/6-fetching-data/components/MyLayout.js
@@ -6,7 +6,7 @@ const layoutStyle = {
   border: '1px solid #DDD'
 }
 
-export default function Layout() {
+export default function Layout(props) {
   return (
     <div style={layoutStyle}>
       <Header />


### PR DESCRIPTION
Fix an error I'm getting `ReferenceError: props is not defined` at https://nextjs.org/learn/basics/fetching-data-for-pages/fetching-batman-shows.