### PR TITLE
Update MyLayout.js

### DIFF
--- a/6-fetching-data/components/MyLayout.js
+++ b/6-fetching-data/components/MyLayout.js
@@ -6,7 +6,7 @@ const layoutStyle = {
   border: '1px solid #DDD'
 }
 
-export default function Layout() {
+export default function Layout(props) {
   return (
     <div style={layoutStyle}>
       <Header />


### PR DESCRIPTION
Added missing props argument to Layout function. I kept getting ReferenceError: props is not defined when trying to run the app as instructed at https://nextjs.org/learn/basics/fetching-data-for-pages/setup. 

Checked the MyLayout.js code and noticed the missing props. The app worked after adding it.