### PR TITLE
Update firebase version

### DIFF
--- a/E2-lazy-loading-modules/package.json
+++ b/E2-lazy-loading-modules/package.json
@@ -18,7 +18,7 @@
     "@zeit/next-bundle-analyzer": "^0.1.2",
     "cross-env": "^5.2.0",
     "express": "^4.16.4",
-    "firebase": "^5.8.6",
+    "firebase": "^6.5.0",
     "next": "^9.0.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4"


### PR DESCRIPTION
Firebase 5.8.6 show an error when run npm install and stuck the tutorial in Learn > Excel > Lazy Loading Modules.

"firebase": "^5.8.6" to "firebase": "^6.5.0"