### PR TITLE
Migrate `@zeit/next-bundle-analyzer` to `@next/bundle-analyzer`

### DIFF
--- a/E3-lazy-loading-components/next.config.js
+++ b/E3-lazy-loading-components/next.config.js
@@ -1,16 +1,4 @@
-const withBundleAnalyzer = require("@zeit/next-bundle-analyzer");
-
-module.exports = withBundleAnalyzer({
-  analyzeServer: ["server", "both"].includes(process.env.BUNDLE_ANALYZE),
-  analyzeBrowser: ["browser", "both"].includes(process.env.BUNDLE_ANALYZE),
-  bundleAnalyzerConfig: {
-    server: {
-      analyzerMode: 'static',
-      reportFilename: '../bundles/server.html'
-    },
-    browser: {
-      analyzerMode: 'static',
-      reportFilename: '../bundles/client.html'
-    }
-  }
-});
+const withBundleAnalyzer = require('@next/bundle-analyzer')({
+  enabled: process.env.ANALYZE === 'true',
+})
+module.exports = withBundleAnalyzer({})

--- a/E3-lazy-loading-components/package.json
+++ b/E3-lazy-loading-components/package.json
@@ -7,9 +7,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "analyze": "cross-env ANALYZE=true next build",
-    "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
-    "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build"
+    "analyze": "cross-env ANALYZE=true next build"
   },
   "keywords": [],
   "author": "",

--- a/E3-lazy-loading-components/package.json
+++ b/E3-lazy-loading-components/package.json
@@ -7,7 +7,7 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "analyze": "cross-env BUNDLE_ANALYZE=both next build",
+    "analyze": "cross-env ANALYZE=true next build",
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build"
   },
@@ -15,7 +15,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@zeit/next-bundle-analyzer": "^0.1.2",
+    "@next/bundle-analyzer": "^9.1.1",
     "cross-env": "^5.2.0",
     "marked": "^0.6.1",
     "next": "^9.0.0",


### PR DESCRIPTION
In `E2-lazy-loading-modules`, it uses `@next/bundle-analyzer`, whereas in `E3-lazy-loading-components`, it uses `@zeit/next-bundle-analyzer`. That causes a confusion which library should be used.

I checked in https://www.npmjs.com/package/@zeit/next-bundle-analyzer and `@zeit/next-bundle-analyzer` was last publish a year ago, but `@next/bundle-analyzer` was last publish 3 days ago (https://www.npmjs.com/package/@next/bundle-analyzer). This makes me come to a conclusion that `@zeit/next-bundle-analyzer` was deprecated in favor of `@next/bundle-analyzer`, and we should migrate to the new one.