### PR TITLE
Update some (not all) package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 yarn.lock
 package-lock.json
+out

--- a/1-navigate-between-pages/package.json
+++ b/1-navigate-between-pages/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/1-navigate-between-pages/package.json
+++ b/1-navigate-between-pages/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/2-using-shared-components/package.json
+++ b/2-using-shared-components/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/2-using-shared-components/package.json
+++ b/2-using-shared-components/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/3-create-dynamic-pages/package.json
+++ b/3-create-dynamic-pages/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/3-create-dynamic-pages/package.json
+++ b/3-create-dynamic-pages/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/4-clean-urls/package.json
+++ b/4-clean-urls/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/4-clean-urls/package.json
+++ b/4-clean-urls/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/6-fetching-data/package.json
+++ b/6-fetching-data/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/6-fetching-data/package.json
+++ b/6-fetching-data/package.json
@@ -12,8 +12,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/7-styling-components/package.json
+++ b/7-styling-components/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "isomorphic-unfetch": "^3.0.0",

--- a/7-styling-components/package.json
+++ b/7-styling-components/package.json
@@ -13,8 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "isomorphic-unfetch": "^3.0.0",
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/7.2-api-routes/package.json
+++ b/7.2-api-routes/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/8-deploying/package.json
+++ b/8-deploying/package.json
@@ -12,9 +12,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
     "react-markdown": "^4.0.6"
   }
 }

--- a/8-deploying/package.json
+++ b/8-deploying/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "next": "latest",

--- a/E1-static-export/package.json
+++ b/E1-static-export/package.json
@@ -1,15 +1,11 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "isomorphic-unfetch": "^3.0.0",

--- a/E1-static-export/package.json
+++ b/E1-static-export/package.json
@@ -13,8 +13,8 @@
   "license": "ISC",
   "dependencies": {
     "isomorphic-unfetch": "^3.0.0",
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/E2-lazy-loading-modules/package.json
+++ b/E2-lazy-loading-modules/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@next/bundle-analyzer": "latest",
     "cross-env": "^5.2.0",
-    "firebase": "^6.5.0",
+    "firebase": "^7.6.2",
     "next": "latest",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/E2-lazy-loading-modules/package.json
+++ b/E2-lazy-loading-modules/package.json
@@ -1,8 +1,6 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "server.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
@@ -11,8 +9,6 @@
     "analyze:server": "cross-env BUNDLE_ANALYZE=server next build",
     "analyze:browser": "cross-env BUNDLE_ANALYZE=browser next build"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "@next/bundle-analyzer": "latest",

--- a/E2-lazy-loading-modules/package.json
+++ b/E2-lazy-loading-modules/package.json
@@ -15,11 +15,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@next/bundle-analyzer": "^9.0.7",
+    "@next/bundle-analyzer": "latest",
     "cross-env": "^5.2.0",
     "firebase": "^6.5.0",
-    "next": "^9.0.7",
-    "react": "^16.10.1",
-    "react-dom": "^16.10.1"
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/E3-lazy-loading-components/package.json
+++ b/E3-lazy-loading-components/package.json
@@ -13,12 +13,12 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@next/bundle-analyzer": "^9.1.1",
+    "@next/bundle-analyzer": "latest",
     "cross-env": "^5.2.0",
     "marked": "^0.6.1",
-    "next": "^9.0.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
+    "next": "latest",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0",
     "react-highlight": "^0.12.0"
   }
 }

--- a/E3-lazy-loading-components/package.json
+++ b/E3-lazy-loading-components/package.json
@@ -1,16 +1,12 @@
 {
   "name": "hello-next",
   "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
   "scripts": {
     "dev": "next",
     "build": "next build",
     "start": "next start",
     "analyze": "cross-env ANALYZE=true next build"
   },
-  "keywords": [],
-  "author": "",
   "license": "ISC",
   "dependencies": {
     "@next/bundle-analyzer": "latest",


### PR DESCRIPTION
- Added `out` to `.gitignore` so it doesn't pollute git index after building
- Update `next` to use `latest`
- Update `react` and `react-dom` to use the latest version
- Update `firebase` because if you tried to do `npm install` with node v12 or v13, it errored with: `Failed at the grpc@1.23.3 install script.` Updating `firebase` which upgrades `grpc` to `1.24.2` seems to solve the issue.
- Removed unused package.json fields